### PR TITLE
(ASC-618) fix nova failure on newton

### DIFF
--- a/molecule/default/tests/test_create_snapshot_on_instance.py
+++ b/molecule/default/tests/test_create_snapshot_on_instance.py
@@ -38,6 +38,9 @@ def test_create_instance_from_image(host):
     utils.create_instance(data_image, host)
     utils.verify_asset_in_list('server', instance_name, host)
 
+    # Verify the new instance is ACTIVE.
+    utils.get_expected_status('server', instance_name, "ACTIVE", host)
+
     # Shutdown the newly created instance
     utils.stop_server_instance(instance_name, host)
 

--- a/molecule/default/tests/utils.py
+++ b/molecule/default/tests/utils.py
@@ -42,7 +42,7 @@ def create_instance(data, run_on_host):
     network_id = get_id_by_name('network', str(data['network_name']), run_on_host)
     instance_name = data['instance_name']
 
-    cmd = "{} openstack server create --{} {} --flavor {} --network {} {}'".format(utility_container, from_source, source_id, flavor, network_id, instance_name)
+    cmd = "{} openstack server create --{} {} --flavor {} --nic net-id={} {} --wait'".format(utility_container, from_source, source_id, flavor, network_id, instance_name)
 
     run_on_host.run_expect([0], cmd)
 
@@ -56,6 +56,7 @@ def verify_asset_in_list(service_type, service_name, run_on_host):
 
 def stop_server_instance(instance_name, run_on_host):
     instance_id = get_id_by_name('server', instance_name, run_on_host)
+
     cmd = "{} openstack server stop {}'".format(utility_container, instance_id)
     run_on_host.run_expect([0], cmd)
 


### PR DESCRIPTION
Prior to this PR, the test uses `--network` argument in `openstack server create` command. The test has been executed successfully in Master(Queens), Pike, and Pike-RC. However, when new CI job of newton is in the pipeline, system test in Newton failed because `openstack server create` in Newton does not recognize the `--network` argument.

Based on Openstack doc, `--network` is a wrapper of `--nic <net-id=network-id, ...>`

This PR does:
1. Replacing argument `--network` by `--nic net-id` so that it would pass on all branches incudling Newton
2. Adding a step of verifying the instance is ACTIVE before shutting it down to avoid the fact that the test is trying to shutdown an non-active instance (building or poweroff) that might cause the test failed