### PR TITLE
(maint) updated tasks/main.yml for nova sumodule

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,25 @@
 ---
 # tasks file for molecule-validate-nova-deploy
 
+- name: Clean old openstack-ansible-ops dir if previously existing
+  file:
+    state: absent
+    path: /opt/openstack-ansible-ops
+
 - name: Clone openstack-ansible-ops repo
   git:
     repo=https://github.com/openstack/openstack-ansible-ops.git
     dest=/opt/openstack-ansible-ops
 
-- name: Install python modules into /opt/ansible-runtime virtualenv
+- name: Create virtualenv for the submodule
+  shell: virtualenv /opt/molecule-test-env-on-sut
+
+- name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
   pip:
     name: "{{ item }}"
+    extra_args: --isolated
     state: present
-    virtualenv: /opt/ansible-runtime
+    virtualenv: /opt/molecule-test-env-on-sut
   with_items:
     - ansible
     - shade
@@ -28,7 +37,7 @@
 
 - name: Create networks
   shell: |
-    . /opt/ansible-runtime/bin/activate
+    . /opt/molecule-test-env-on-sut/bin/activate
     ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {{ inventory_file }} openstack-service-setup.yml
     deactivate
   args:


### PR DESCRIPTION
This PR is to update the tasks/main.yml to be identical with other submodules (cinder, neutron, glance). The changes are making sure to:
1. Delete pre-existing /opt/openstack-ansible-ops dir in infra1 (this sometimes causes failure for ansible git clone task
2. Create an isolated python environment for running the openstack-service-setup playbook
3. Install pyhthon packages onto the virtualenv in step2 with '--isolated' flag.