### PR TITLE
(ASC-855) openstack-service-setup should run once(nova)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 # tasks file for molecule-validate-nova-deploy
 
 - import_tasks: cloning_openstack_ansible_ops.yml
-  when: openstack_service_setup_already_ran_successfully is not defined
+  when: ansible_local.service_setup is not defined
 
 - import_tasks: create_virtualenv_on_sut.yml
-  when: openstack_service_setup_already_ran_successfully is not defined
+  when: ansible_local.service_setup is not defined
 
 - import_tasks: run_openstack_service_setup_playbook.yml
-  when: openstack_service_setup_already_ran_successfully is not defined
+  when: ansible_local.service_setup is not defined
 
 - import_tasks: server_delete.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,12 @@
 # tasks file for molecule-validate-nova-deploy
 
 - import_tasks: cloning_openstack_ansible_ops.yml
+  when: openstack_service_setup_already_ran_successfully is not defined
+
 - import_tasks: create_virtualenv_on_sut.yml
+  when: openstack_service_setup_already_ran_successfully is not defined
+
 - import_tasks: run_openstack_service_setup_playbook.yml
+  when: openstack_service_setup_already_ran_successfully is not defined
+
 - import_tasks: server_delete.yml

--- a/tasks/run_openstack_service_setup_playbook.yml
+++ b/tasks/run_openstack_service_setup_playbook.yml
@@ -18,3 +18,7 @@
   args:
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
+
+- name: openstack-service-setup.yml was running successfully
+  set_fact:
+    openstack_service_setup_already_ran_successfully: true

--- a/tasks/run_openstack_service_setup_playbook.yml
+++ b/tasks/run_openstack_service_setup_playbook.yml
@@ -19,6 +19,16 @@
     executable: /bin/bash
     chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
 
-- name: openstack-service-setup.yml was running successfully
-  set_fact:
-    openstack_service_setup_already_ran_successfully: true
+- name: create directory for ansible custome facts
+  file:
+    state: directory
+    recurse: yes
+    path: /etc/ansible/facts.d
+
+- name: install custom fact for service setup
+  copy:
+    content: "{\"already_ran\" : \"true\"}"
+    dest: /etc/ansible/facts.d/service_setup.fact
+
+- name: re-read facts after adding custome fact
+  setup: filter=ansible_local


### PR DESCRIPTION
System tests run openstack-service-setup.yml in each and every single molecule submodule, this duplication effort is unnecessary, slowing down test, and causing errors when idempotent is failing.

This PR adds condition check, if openstack-service-setup.yml has been run successfully once, it should not run again.