### PR TITLE
ASC-789 virtualenv python3 on master/rocky

### DIFF
--- a/tasks/create_virtualenv_on_sut.yml
+++ b/tasks/create_virtualenv_on_sut.yml
@@ -1,8 +1,17 @@
 ---
 # tasks file for molecule-validate-nova-deploy
 
-- name: Create virtualenv for the submodule
+- name: Create python2 virtualenv for the submodule
   shell: virtualenv /opt/molecule-test-env-on-sut
+  when:
+    - rpc_product_release != "master" or
+      rpc_product_release != "rocky"
+
+- name: Create python3 virtualenv for the submodule
+  shell: virtualenv --python=python3 /opt/molecule-test-env-on-sut
+  when:
+    - rpc_product_release == "master" or
+      rpc_product_release == "rocky"
 
 - name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,25 @@
 ---
 # tasks file for molecule-validate-nova-deploy
+- name: Set the rpc-openstack variables
+  set_fact:
+    rpc_openstack: "{{ ansible_local['rpc_openstack']['rpc_product'] }}"
+  when:
+    - ansible_local.rpc_openstack is defined
+    - ansible_local.rpc_openstack.rpc_product is defined
+- name: Set the rpc-release variable
+  set_fact:
+    rpc_product_release: "{{ rpc_openstack['rpc_product_release'] }}"
+  when:
+    - rpc_openstack is defined
+    - rpc_openstack['rpc_product_release'] is defined
+    - rpc_product_release is undefined or
+      rpc_product_release == 'undefined'
+- name: Set the rpc-release variable from environment
+  set_fact:
+    rpc_product_release: "{{ lookup('env', 'RPC_PRODUCT_RELEASE') }}"
+  when:
+    - rpc_openstack is undefined or
+      rpc_openstack['rpc_product_release'] is undefined
 
 - import_tasks: cloning_openstack_ansible_ops.yml
   when: ansible_local.service_setup is not defined


### PR DESCRIPTION
This commit updates the converge virtualenv setup to deploy python3
when testing on "master" or "rocky", otherwise the standard python
environment is used for the virtualenv.