### PR TITLE
(maint) Remove cleaning step of deleting floating ip

### DIFF
--- a/molecule/default/tests/test_create_and_assign_floating_ip.py
+++ b/molecule/default/tests/test_create_and_assign_floating_ip.py
@@ -74,6 +74,3 @@ def test_assign_floating_ip_to_instance(host):
     # Ensure the IP can be pinged from infra1
     cmd = "ping -c1 {}".format(floating_ip)
     assert (host.run_expect([0], cmd))
-
-    # Cleaning test env after testing: Delete floating IP
-    helpers.delete_it('floating ip', floating_ip, host)


### PR DESCRIPTION
Currently this step causes build failure since there might be a minor bug in the helper, this step does not effect the test and we are investigating a major issue of creating instance failure.
Will revert the step after the issue is totally resolved