### PR TITLE
(ASC-896) install correct pip on SUT when test nova against RPC-O master

### DIFF
--- a/tasks/create_virtualenv_on_sut.yml
+++ b/tasks/create_virtualenv_on_sut.yml
@@ -2,16 +2,30 @@
 # tasks file for molecule-validate-nova-deploy
 
 - name: Create python2 virtualenv for the submodule
-  shell: virtualenv /opt/molecule-test-env-on-sut
+  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
+    /opt/molecule-test-env-on-sut
   when:
     - rpc_product_release != "master" or
       rpc_product_release != "rocky"
 
 - name: Create python3 virtualenv for the submodule
-  shell: virtualenv --python=python3 /opt/molecule-test-env-on-sut
+  shell: virtualenv --no-pip --no-setuptools --no-wheel --no-download --no-site-packages  \
+    --python=python3 /opt/molecule-test-env-on-sut
   when:
     - rpc_product_release == "master" or
       rpc_product_release == "rocky"
+
+- name: Install pip/setuptools/wheel on the virtualenv on SUT
+  shell: |
+    . /opt/molecule-test-env-on-sut/bin/activate
+    CURL_CMD="curl --silent --show-error --retry 5"
+    OUTPUT_FILE="get-pip.py"
+    ${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > ${OUTPUT_FILE}  \
+      || ${CURL_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > ${OUTPUT_FILE}
+    GETPIP_OPTIONS="pip setuptools wheel"
+    python ${OUTPUT_FILE} ${GETPIP_OPTIONS} \
+      || python ${OUTPUT_FILE} --isolated ${GETPIP_OPTIONS}
+    deactivate
 
 - name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
   pip:


### PR DESCRIPTION
Prior to this PR, virtualenv fails to install setuptools on SUT if testing against RPC-O master, possibly because it uses a very old pip (8.1.1) while current pip version is 18.

This PR is trying to solve the old pip by not using the available pip on host, instead it will download and install new pip from pypa